### PR TITLE
Add startTime/endTime to lifelogs

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -69,6 +69,14 @@ components:
           items:
             $ref: "#/components/schemas/ContentNode"
           description: List of ContentNodes.
+        startTime:
+          type: string
+          format: date-time
+          description: ISO format in given timezone.
+        endTime:
+          type: string
+          format: date-time
+          description: ISO format in given timezone.
 
     MetaLifelogs:
       type: object


### PR DESCRIPTION
- Adds startTime/endTime to `v1/lifelogs` results.