### PR TITLE
Improve type specification

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -18,7 +18,7 @@ components:
       properties:
         type:
           type: string
-          description: Type of content node (e.g., heading1, heading2, heading3, blockquote). More types might be added.
+          description: Type of content node (e.g., heading1, heading2, heading3, blockquote, paragraph). More types might be added.
         content:
           type: string
           description: Content of the node.

--- a/python/_client.py
+++ b/python/_client.py
@@ -15,7 +15,7 @@ def get_lifelogs(api_key, api_url=os.getenv("LIMITLESS_API_URL") or "https://api
         params = {  
             "limit": batch_size,
             "includeMarkdown": "true" if includeMarkdown else "false",
-            "includeHeadings": "false" if includeHeadings else "true",
+            "includeHeadings": "true" if includeHeadings else "false",
             "date": date,
             "direction": direction,
             "timezone": timezone if timezone else str(tzlocal.get_localzone())


### PR DESCRIPTION
This PR makes two small fixes.
- `includeHeadings` is correctly evaluated as a boolean
- `paragraph` included in openapi.yml description for ContentNode type